### PR TITLE
fix: keep rebounded note at top and update keyMap immediately + add load state

### DIFF
--- a/src/app/api/notes/[noteId]/route.ts
+++ b/src/app/api/notes/[noteId]/route.ts
@@ -11,8 +11,9 @@ interface Params {
 
 export async function PUT(
   req: Request,
-  { params: { noteId } }: Params
+  { params }: { params: Promise<{ noteId: string }> }
 ) {
+  const { noteId } = await params;
   // auth
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) {
@@ -84,8 +85,9 @@ export async function PUT(
 
 export async function DELETE(
   req: Request,
-  { params: { noteId } }: Params
+  { params }: { params: Promise<{ noteId: string }> }
 ) {
+  const { noteId } = await params;
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });


### PR DESCRIPTION
Fixed a few bugs in the note-ui. 

1. Reassigning notecards new keybinds correctly reflects change within UI both internally and externally and keeps changes note at the top per selection.
2. Add load state to assign keybind portal. 
3. Fix NextJS params error inside note/[noteId]/route.ts 